### PR TITLE
Improve double payment handling

### DIFF
--- a/draft bot.py
+++ b/draft bot.py
@@ -6,9 +6,11 @@ import json
 import os
 import datetime
 import random
+import string
 import asyncio
 from discord.ui import Modal, TextInput
 from discord import TextStyle
+import re
 
 
 load_dotenv()
@@ -115,6 +117,25 @@ def disable_all_buttons(view: discord.ui.View):
             item.disabled = True
 
 
+async def disable_queue_buttons(channel):
+    """Disable join/leave buttons once the draft starts."""
+    data = load_drafts()
+    draft = data.get(str(channel.id))
+    if not draft:
+        return
+    message_id = draft.get("queue_message_id")
+    if not message_id:
+        return
+    try:
+        msg = await channel.fetch_message(message_id)
+        team_count = int(draft["team_size"][0])
+        view = DraftQueueView(channel.id, team_count * 2)
+        disable_all_buttons(view)
+        await msg.edit(view=view)
+    except Exception as e:
+        print(f"Error disabling queue buttons: {e}")
+
+
 def generate_final_teams_embed(draft):
     embed = discord.Embed(
         title="📋 Final Teams",
@@ -164,38 +185,11 @@ class ManualStartView(discord.ui.View):
             return
 
         await interaction.response.send_message("⏩ Manually starting the draft...", ephemeral=True)
-        await auto_start_draft(interaction.guild, interaction.channel)
+        await auto_start_draft(interaction.guild, interaction.channel, skip_middleman=True)
 
-
-class SubmitCashTag(Modal, title="Submit Your Cash App Tag"):
-    def __init__(self, user_id: int, channel_id: int):
-        super().__init__()
-        self.user_id = user_id
-        self.channel_id = channel_id
-
-        self.cash_tag_input = TextInput(
-            label="Enter your exact $CashTag (without the $)",
-            placeholder="e.g. john123",
-            style=TextStyle.short,
-            required=True
-        )
-        self.add_item(self.cash_tag_input)
-
-    async def on_submit(self, interaction: discord.Interaction):
-        submitted_tag = self.cash_tag_input.value.strip()
-
-        data = load_drafts()
-        draft = data.get(str(self.channel_id))
-        if draft:
-            if "cash_tags" not in draft:
-                draft["cash_tags"] = {}
-            draft["cash_tags"][str(self.user_id)] = submitted_tag
-            save_drafts(data)
-
-        await interaction.response.send_message("✅ Your Cash App tag was submitted!", ephemeral=True)
 
 class MiddleManForm(discord.ui.Modal, title="Middle Man Setup"):
-    cashapp = discord.ui.TextInput(label="Enter your Cash App tag", placeholder="$yourtag", required=True)
+    cashapp = discord.ui.TextInput(label="Enter your Cash App username", placeholder="e.g. johndoe", required=True)
 
     def __init__(self, channel_id):
         super().__init__()
@@ -218,19 +212,24 @@ class MiddleManForm(discord.ui.Modal, title="Middle Man Setup"):
         await begin_cashapp_collection(interaction.guild, interaction.channel)
 
 class MiddleManButton(discord.ui.View):
-    def __init__(self, channel_id, role_id):
+    def __init__(self, channel_id):
         super().__init__(timeout=None)
         self.channel_id = channel_id
-        self.role_id = role_id
 
     @discord.ui.button(label="I'm the Middle Man", style=discord.ButtonStyle.primary)
     async def confirm_mm(self, interaction: discord.Interaction, button: discord.ui.Button):
         # Optional: permission check
-        if not await has_role(interaction.user, ["Middleman", "Draft Admin"]):
+        if MIDDLEMAN_ROLE_ID not in [role.id for role in interaction.user.roles]:
             await interaction.response.send_message("You don't have permission to be the Middle Man.", ephemeral=True)
             return
 
-        # ✅ Send the modal to collect the Cash App tag
+        data = load_drafts()
+        draft = data.get(str(self.channel_id))
+        if draft is not None:
+            draft["middleman_id"] = interaction.user.id
+            save_drafts(data)
+
+        # ✅ Send the modal to collect the Cash App username
         await interaction.response.send_modal(MiddlemanCashTagModal(self.channel_id))
 
 
@@ -240,28 +239,40 @@ class CashAppSubmitView(discord.ui.View):
         super().__init__(timeout=None)
         self.channel_id = channel_id
 
-@discord.ui.button(label="Submit Cash App Tag", style=discord.ButtonStyle.green)
-async def submit_tag(self, interaction: discord.Interaction, button: discord.ui.Button):
-    await interaction.response.send_modal(
-        SubmitCashTag(user_id=interaction.user.id, channel_id=self.channel_id)
-    )
+    @discord.ui.button(label="Submit Cash App Username", style=discord.ButtonStyle.green)
+    async def submit_tag(self, interaction: discord.Interaction, button: discord.ui.Button):
+        data = load_drafts()
+        draft = data.get(str(self.channel_id))
+        if not draft:
+            await interaction.response.send_message("Draft not found.", ephemeral=True)
+            return
 
-    # Store player cash tags for this draft channel
-    draft = load_drafts().get(str(self.channel_id))
-    if draft:
-        pending_payments[str(self.channel_id)] = {
-            tag: int(uid) for uid, tag in draft.get("cash_tags", {}).items()
-        }
-        confirmed_payments[str(self.channel_id)] = set()
+        if interaction.user.id not in draft.get("players", []):
+            await interaction.response.send_message(
+                "❌ Only players in the draft queue can submit a Cash App username.",
+                ephemeral=True,
+            )
+            return
+
+        already = draft.get("player_tags", {}).get(str(interaction.user.id))
+        if already:
+            await interaction.response.send_message("You've already submitted your username.", ephemeral=True)
+            return
+
+        await interaction.response.send_modal(PlayerCashTagForm(self.channel_id))
 
 
 
 
-class PlayerCashTagForm(discord.ui.Modal, title="Enter Your Cash App Tag"):
+class PlayerCashTagForm(discord.ui.Modal, title="Enter Your Cash App Username"):
     def __init__(self, channel_id):
         super().__init__()
         self.channel_id = channel_id
-        self.cashapp = discord.ui.TextInput(label="Cash App Tag", placeholder="$example", required=True)
+        self.cashapp = discord.ui.TextInput(
+            label="**Cash App USERNAME** (not $tag)",
+            placeholder="e.g. johndoe",
+            required=True,
+        )
         self.add_item(self.cashapp)
 
     async def on_submit(self, interaction: discord.Interaction):
@@ -271,38 +282,228 @@ class PlayerCashTagForm(discord.ui.Modal, title="Enter Your Cash App Tag"):
         if "player_tags" not in draft:
             draft["player_tags"] = {}
 
-        draft["player_tags"][str(interaction.user.id)] = self.cashapp.value
+        if interaction.user.id not in draft.get("players", []):
+            await interaction.response.send_message(
+                "❌ You are not in this draft's queue.", ephemeral=True
+            )
+            return
+
+        tag = self.cashapp.value.strip().lower()
+        existing = [t.lower() for t in draft.get("player_tags", {}).values()]
+        if tag in existing:
+            await interaction.response.send_message(
+                "❌ That Cash App username is already used by another player.",
+                ephemeral=True,
+            )
+            return
+        if len(tag) <= 3:
+            await interaction.response.send_message(
+                "❌ Cash App username must be longer than 3 characters.", ephemeral=True
+            )
+            return
+
+        if str(interaction.user.id) in draft["player_tags"]:
+            await interaction.response.send_message(
+                "You already submitted your Cash App username.", ephemeral=True
+            )
+            return
+
+        draft["player_tags"][str(interaction.user.id)] = tag
         save_drafts(data)
 
-        await interaction.response.send_message("✅ Cash App tag submitted!", ephemeral=True)
+        await interaction.response.send_message("✅ Cash App username submitted!", ephemeral=True)
 
         channel = interaction.client.get_channel(self.channel_id)
         if channel:
-            await channel.send(f"📝 {interaction.user.mention} has submitted their Cash App tag.")
+            await channel.send(f"📝 {interaction.user.mention} has submitted their Cash App username.")
 
-        # ⬇️ MOVE THE CHECK HERE — inside the async function
         if draft:
             if len(draft.get("player_tags", {})) == len(draft.get("players", [])):
-                # All players submitted — show middleman's Cash App
                 await send_payment_instructions(channel)
             else:
-                print(f"{len(draft['player_tags'])}/{len(draft['players'])} Cash Tags submitted")
+                print(
+                    f"{len(draft['player_tags'])}/{len(draft['players'])} Cash Tags submitted"
+                )
 
 
 
 class PaymentControlView(discord.ui.View):
+    def __init__(self, channel_id, *, double: bool = False):
+        super().__init__(timeout=None)
+        self.channel_id = channel_id
+        self.double = double
+
+    @discord.ui.button(label="Start Draft Manually", style=discord.ButtonStyle.red)
+    async def manual_start(self, interaction: discord.Interaction, button: discord.ui.Button):
+        data = load_drafts()
+        draft = data.get(str(self.channel_id))
+
+        if not draft:
+            await interaction.response.send_message("Draft not found.", ephemeral=True)
+            return
+
+        if interaction.user.id != draft.get("middleman_id"):
+            await interaction.response.send_message("Only the selected middle man can start the draft.", ephemeral=True)
+            return
+
+        await interaction.response.send_message("✅ Starting manually...", ephemeral=True)
+        if self.double:
+            # For double or nothing just mark it complete and announce
+            data = load_drafts()
+            draft = data.get(str(self.channel_id), {})
+            if "double" in draft:
+                draft["double"]["state"] = "complete"
+            save_drafts(data)
+            await interaction.channel.send("@everyone Double or Nothing started manually!")
+        else:
+            await auto_start_draft(interaction.guild, interaction.channel, skip_middleman=True)
+
+
+class DoublePromptView(discord.ui.View):
     def __init__(self, channel_id):
         super().__init__(timeout=None)
         self.channel_id = channel_id
 
-    @discord.ui.button(label="Start Draft Manually", style=discord.ButtonStyle.red)
-    async def manual_start(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if not await has_role(interaction.user, ["Draft Admin", "Middleman"]):
-            await interaction.response.send_message("You don’t have permission to start the draft.", ephemeral=True)
+    @discord.ui.button(label="Double", style=discord.ButtonStyle.green)
+    async def double(self, interaction: discord.Interaction, button: discord.ui.Button):
+        data = load_drafts()
+        draft = data.get(str(self.channel_id))
+        if not draft:
+            await interaction.response.send_message("Draft not found.", ephemeral=True)
             return
 
-        await interaction.response.send_message("✅ Starting draft manually...", ephemeral=True)
-        await auto_start_draft(interaction.channel)
+        if interaction.user.id not in draft.get("players", []):
+            await interaction.response.send_message("You are not part of this draft.", ephemeral=True)
+            return
+
+        double = draft.setdefault("double", {"state": "voting", "votes": []})
+        if interaction.user.id not in double["votes"]:
+            double["votes"].append(interaction.user.id)
+            save_drafts(data)
+
+        total = len(draft.get("players", []))
+        if len(double["votes"]) == total:
+            double["state"] = "loser_select"
+            save_drafts(data)
+            disable_all_buttons(self)
+            await interaction.message.edit(view=self)
+            await interaction.response.send_message("All players agreed! Select the losing team.")
+            await send_loser_selection(interaction.channel)
+        else:
+            await interaction.response.send_message(
+                f"{len(double['votes'])}/{total} players voted to double.", ephemeral=True
+            )
+
+    @discord.ui.button(label="Close Draft", style=discord.ButtonStyle.red)
+    async def close(self, interaction: discord.Interaction, button: discord.ui.Button):
+        disable_all_buttons(self)
+        await interaction.message.edit(view=self)
+        await interaction.response.send_message("Draft closed. Use /enddraft to log results.")
+
+
+class LoserSelectView(discord.ui.View):
+    def __init__(self, channel_id, options):
+        super().__init__(timeout=None)
+        self.channel_id = channel_id
+        select = discord.ui.Select(placeholder="Select losing team", options=options)
+
+        async def select_callback(interaction: discord.Interaction):
+            choice = select.values[0]
+            data = load_drafts()
+            draft = data.get(str(self.channel_id))
+            if not draft:
+                await interaction.response.send_message("Draft not found.", ephemeral=True)
+                return
+
+            captains = [draft.get("captains", {}).get("team1"), draft.get("captains", {}).get("team2")]
+            if interaction.user.id not in captains:
+                await interaction.response.send_message("Only team captains can choose the losing team.", ephemeral=True)
+                return
+            double = draft.setdefault("double", {})
+            votes = double.setdefault("loser_votes", {})
+            votes[str(interaction.user.id)] = choice
+            save_drafts(data)
+
+            if len(votes) < 2:
+                await interaction.response.send_message("Vote recorded. Waiting for the other captain...", ephemeral=True)
+                return
+
+            values = list(votes.values())
+            if values[0] != values[1]:
+                double["loser_votes"] = {}
+                save_drafts(data)
+                await interaction.response.send_message(
+                    "❌ Captains selected different teams. Please agree on the loser.",
+                    ephemeral=True,
+                )
+                return
+
+            # Both captains agree
+            double["state"] = "collecting"
+            double["loser_team"] = values[0]
+            double["loser_votes"] = {}
+            save_drafts(data)
+
+            if values[0] == "team1":
+                players = [draft["captains"]["team1"]] + draft.get("team1", [])
+            else:
+                players = [draft["captains"]["team2"]] + draft.get("team2", [])
+
+            disable_all_buttons(self)
+            await interaction.message.edit(view=self)
+            await interaction.response.send_message("Collecting double payment from the losing team...")
+            await send_payment_instructions(interaction.channel, players=players, double=True)
+
+        select.callback = select_callback
+        self.add_item(select)
+
+
+async def send_double_prompt(channel):
+    data = load_drafts()
+    draft = data.get(str(channel.id))
+    if not draft:
+        return
+
+    draft["double"] = {"state": "voting", "votes": []}
+    save_drafts(data)
+
+    embed = discord.Embed(
+        title="Double or Nothing?",
+        description=(
+            "If the losing team wants a rematch for double the stakes, click **Double**.\n"
+            "Otherwise click **Close Draft**."
+        ),
+        color=discord.Color.purple(),
+    )
+    view = DoublePromptView(channel.id)
+    await channel.send(embed=embed, view=view)
+
+
+async def send_loser_selection(channel):
+    data = load_drafts()
+    draft = data.get(str(channel.id))
+    if not draft:
+        return
+
+    t1_members = [draft["captains"]["team1"]] + draft.get("team1", [])
+    t2_members = [draft["captains"]["team2"]] + draft.get("team2", [])
+
+    def names(ids):
+        members = [channel.guild.get_member(uid) for uid in ids]
+        return ", ".join(m.display_name for m in members if m)
+
+    options = [
+        discord.SelectOption(label="Team 1", description=names(t1_members), value="team1"),
+        discord.SelectOption(label="Team 2", description=names(t2_members), value="team2"),
+    ]
+
+    embed = discord.Embed(
+        title="Who lost the match?",
+        description="Select the losing team to start the double payment process.",
+        color=discord.Color.orange(),
+    )
+    view = LoserSelectView(channel.id, options)
+    await channel.send(embed=embed, view=view)
 
 
 
@@ -348,37 +549,24 @@ async def begin_cashapp_collection(guild, channel):
     if not draft:
         return
 
+    middleman = f"<@{draft.get('middleman_id')}>" if draft.get('middleman_id') else "Middleman"
+    player_mentions = " ".join(f"<@{uid}>" for uid in draft.get("players", []))
+
     embed = discord.Embed(
-        title="💵 Submit Your Cash App Tag",
+        title="💵 Payment Username Collection",
         description=(
-            "Click the button below to submit your Cash App tag. "
-            "Once everyone sends payment, the draft will start automatically.\n\n"
-            "If someone doesn’t send their payment, the **middleman** can manually start the draft."
+            f"{middleman} will hold the pot.\n"
+            f"{player_mentions}\n"
+            "Click below and enter your **Cash App USERNAME** (not $tag)."
         ),
-        color=discord.Color.green()
+        color=discord.Color.green(),
     )
-    
+
     view = CashAppSubmitView(channel_id=channel.id)
     manual_view = ManualStartView(channel_id=channel.id)
 
     await channel.send(embed=embed, view=view)
     await channel.send(view=manual_view)
-
-    for uid in draft["players"]:
-        member = guild.get_member(uid)
-        if member:
-            try:
-                view = discord.ui.View()
-                button = discord.ui.Button(label="Submit Cash App Tag", style=discord.ButtonStyle.primary)
-
-                async def callback(interaction: discord.Interaction, user_id=uid, channel_id=channel.id):
-                    await interaction.response.send_modal(PlayerCashTagForm(user_id, channel_id))
-
-                button.callback = callback
-                view.add_item(button)
-                await member.send("Please submit your Cash App tag:", view=view)
-            except:
-                print(f"Could not DM user {uid}")
 
 async def send_middleman_selection(channel):
     data = load_drafts()
@@ -386,42 +574,63 @@ async def send_middleman_selection(channel):
     if not draft:
         return
 
-    role_id = draft.get("middleman_role_id")
-    if not role_id:
-        return
-
     embed = discord.Embed(
-        title="✅ Middle Man Selected: <#{}>".format(channel.id),
-        description="Click the button below if you're the Middleman.\nYou'll be prompted to enter your Cash App tag.",
+        title="⏳ Waiting for Middle Man",
+        description="Click the button below if you're the Middleman.\nYou'll be prompted to enter your Cash App **tag**.",
         color=discord.Color.orange()
     )
-    view = MiddleManButton(channel.id, role_id)
-    await channel.send(embed=embed, view=view)
+    view = MiddleManButton(channel.id)
+    msg = await channel.send(embed=embed, view=view)
+    draft["middleman_select_msg_id"] = msg.id
+    save_drafts(data)
 
 
-async def send_payment_instructions(channel):
+async def send_payment_instructions(channel, players=None, *, double: bool = False):
     data = load_drafts()
     draft = data.get(str(channel.id))
     if not draft:
         return
 
+    if players is None:
+        players = draft.get("players", [])
+
     entry = draft.get("entry_amount", 0)
-    middleman_tag = draft.get("middleman_cashapp", "$unknown")
-    total = entry * len(draft["players"])
+    middleman_tag = draft.get("middleman_cash_tag", "$unknown")
+    total = entry * len(players)
+
+    # Generate a unique 3-letter note for this draft
+    note = ''.join(random.choice(string.ascii_uppercase) for _ in range(3))
+    draft["payment_note"] = note
+    save_drafts(data)
+
+    pending_payments[str(channel.id)] = {
+        draft["player_tags"].get(str(uid)): uid
+        for uid in players
+        if str(uid) in draft.get("player_tags", {})
+    }
+    confirmed_payments[str(channel.id)] = set()
+
+    title = "💰 Payment Instructions" if not double else "💰 Double or Nothing Payment"
 
     embed = discord.Embed(
-        title="💰 Payment Instructions",
-        description=f"Please send your entry fee to the middleman before the match begins.",
+        title=title,
+        description=(
+            f"Send your entry fee to the middleman now and include the note `{note}`.\n"
+            "Payments without the correct note will not be detected."
+        ),
         color=discord.Color.gold()
     )
-    embed.add_field(name="📲 Middleman's Cash App", value=middleman_tag, inline=False)
+    embed.add_field(name="📲 Middleman's Cash App Tag", value=middleman_tag, inline=False)
     embed.add_field(name="💵 Amount to Send", value=f"${entry}", inline=False)
-    embed.add_field(name="📦 Total Expected", value=f"${total} total from {len(draft['players'])} players", inline=False)
+    embed.add_field(name="📦 Total Expected", value=f"${total} total from {len(players)} players", inline=False)
+    embed.add_field(name="🔒 Required Note", value=f"`{note}`", inline=False)
     embed.set_footer(text="Once all payments are confirmed, the draft will begin.")
 
+    player_mentions = " ".join(f"<@{uid}>" for uid in players)
+
     # Manual Start Button
-    view = PaymentControlView(channel.id)
-    await channel.send(embed=embed, view=view)
+    view = PaymentControlView(channel.id, double=double)
+    await channel.send(content=player_mentions, embed=embed, view=view)
 
 
 async def send_pick_options(channel):
@@ -468,55 +677,6 @@ class GoToDraftButton(discord.ui.View):
 
 
 
-class MiddleManButton(discord.ui.View):
-    def __init__(self, channel_id, role_id):
-        super().__init__(timeout=None)
-        self.channel_id = str(channel_id)
-        self.role_id = role_id
-        self.middleman = None
-
-    @discord.ui.button(label="✅ I'm the Middle Man", style=discord.ButtonStyle.success)
-    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if self.role_id not in [role.id for role in interaction.user.roles]:
-            await interaction.response.send_message("❌ Only a Middle Man can click this.", ephemeral=True)
-            return
-
-        self.middleman = interaction.user
-        await interaction.channel.set_permissions(self.middleman, send_messages=True)
-        for child in self.children:
-            child.disabled = True
-        await interaction.message.edit(content=f"✅ Middle Man Selected: {interaction.user.mention}", view=self)
-        await interaction.response.send_message("Thank you! Now send proof of payments.", ephemeral=True)
-
-        # Proceed with the draft start here
-        await send_payment_confirmation(interaction.channel, interaction.user)
-
-async def send_payment_confirmation(channel, middleman):
-    embed = discord.Embed(
-        title="💸 Send Payments",
-        description=f"All participants must now send their payments to {middleman.mention}.\n\nOnce all payments are confirmed, the Middle Man should confirm below.",
-        color=discord.Color.gold()
-    )
-    view = ConfirmPaymentButton(middleman.id)
-    await channel.send(embed=embed, view=view)
-
-
-class ConfirmPaymentButton(discord.ui.View):
-    def __init__(self, middleman_id):
-        super().__init__(timeout=None)
-        self.middleman_id = middleman_id
-
-    @discord.ui.button(label="✅ Confirm All Payments Received", style=discord.ButtonStyle.primary)
-    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):
-        if interaction.user.id != self.middleman_id:
-            await interaction.response.send_message("❌ Only the selected Middle Man can confirm this.", ephemeral=True)
-            return
-
-        for child in self.children:
-            child.disabled = True
-        await interaction.message.edit(content="✅ All payments received. Starting draft...", view=self)
-        await send_actual_draft_start(interaction.channel)
-        await send_pick_options(interaction.channel)
 
     
 class DraftQueueView(discord.ui.View):
@@ -605,14 +765,19 @@ class MiddlemanCashTagModal(discord.ui.Modal, title="Enter Your Cash App Tag"):
         self.channel_id = channel_id
 
         self.cash_tag = discord.ui.TextInput(
-            label="Your Cash App Tag (without $)",
-            placeholder="e.g. johndoe123",
+            label="Cash App Tag (include $)",
+            placeholder="$example",
             required=True
         )
         self.add_item(self.cash_tag)
 
     async def on_submit(self, interaction: discord.Interaction):
         submitted_tag = self.cash_tag.value.strip()
+        if len(submitted_tag) <= 3:
+            await interaction.response.send_message(
+                "❌ Cash App tag must be longer than 3 characters.", ephemeral=True
+            )
+            return
         data = load_drafts()
         draft = data.get(str(self.channel_id), {})
         draft["middleman_cash_tag"] = submitted_tag
@@ -622,41 +787,33 @@ class MiddlemanCashTagModal(discord.ui.Modal, title="Enter Your Cash App Tag"):
             f"✅ Your Cash App tag `{submitted_tag}` has been saved.", ephemeral=True
         )
 
-        # 🔔 Notify the channel
         channel = interaction.guild.get_channel(self.channel_id)
-        if not channel:
-            return
+        if channel:
+            # Disable the middleman selection button now that it's confirmed
+            try:
+                data = load_drafts()
+                draft = data.get(str(self.channel_id), {})
+                msg_id = draft.get("middleman_select_msg_id")
+                if msg_id:
+                    msg = await channel.fetch_message(msg_id)
+                    view = MiddleManButton(self.channel_id)
+                    disable_all_buttons(view)
+                    await msg.edit(content=f"✅ Middleman: {interaction.user.mention}", view=view)
+            except Exception as e:
+                print(f"Error disabling middleman button: {e}")
 
-        amount = draft.get("entry_amount", 0)
-        cash_tag_display = f"${submitted_tag}"
-
-        embed = discord.Embed(
-            title="💵 Payment Phase",
-            description=(
-                f"Please send **${amount}** to the middleman at `{cash_tag_display}`.\n\n"
-                "Each player must submit payment to continue."
-            ),
-            color=discord.Color.gold()
-        )
-        embed.set_footer(text="Use Cash App and make sure to send the correct amount.")
-
-        view = ManualStartView(channel_id=self.channel_id)
-        await channel.send(embed=embed, view=view)
+            await begin_cashapp_collection(interaction.guild, channel)
 
 
 
 
 @tree.command(name="createdraft", description="Create a new draft")
 @app_commands.describe(
-    draft_type="Is this a friendly or wager draft?",
-    entry_amount="Amount each player pays (only for wager drafts)",
     team_size="Choose 3v3 or 4v4",
+    is_money_draft="Require Cash App payment?",
+    entry_fee="Dollar amount each player must pay",
     snake_draft="Enable snake draft"
 )
-@app_commands.choices(draft_type=[
-    app_commands.Choice(name="Friendly", value="friendly"),
-    app_commands.Choice(name="Wager", value="wager")
-])
 @app_commands.choices(team_size=[
     app_commands.Choice(name="3v3", value="3v3"),
     app_commands.Choice(name="4v4", value="4v4"),
@@ -666,8 +823,8 @@ class MiddlemanCashTagModal(discord.ui.Modal, title="Enter Your Cash App Tag"):
 async def createdraft(
     interaction: discord.Interaction,
     team_size: app_commands.Choice[str],
-    draft_type: app_commands.Choice[str],
-    entry_amount: int = 0,
+    is_money_draft: bool = False,
+    entry_fee: app_commands.Range[int, 0, None] = 0,
     snake_draft: bool = True,
 ):
     team_count = int(team_size.name[0])
@@ -676,13 +833,11 @@ async def createdraft(
     now = int(datetime.datetime.now().timestamp())      # For Discord timestamp formatting
     now = int(datetime.datetime.now().timestamp())
 
-    # Save wager/friendly type and entry amount
-# Save wager/friendly type and entry amount
     draft_data = {
         "team_size": team_size.value,
         "snake_draft": snake_draft,
-        "draft_type": draft_type.value,
-        "entry_amount": entry_amount if draft_type.value == "wager" else 0,
+        "is_money_draft": is_money_draft,
+        "entry_amount": entry_fee,
         "date": now,
         "players": [],
         "team1": [],
@@ -692,7 +847,7 @@ async def createdraft(
         "team_roles": {},
         "available": [],
         "pick_turn": "team1"
-}
+    }
 
 
 
@@ -736,6 +891,8 @@ async def createdraft(
     embed.add_field(name="📅 Date:", value=f"<t:{now}:F>", inline=False)
     embed.add_field(name="🎙️ Host:", value=interaction.user.mention, inline=False)
     embed.add_field(name="🐍 Snake Draft:", value="Yes" if snake_draft else "No", inline=False)
+    if is_money_draft and entry_fee > 0:
+        embed.add_field(name="💵 Entry Fee", value=f"${entry_fee}", inline=False)
     embed.set_footer(text=f"Queue: 0/{max_players} • Made by blur.exe")
 
     view = DraftQueueView(channel.id, max_players)
@@ -1004,7 +1161,7 @@ async def enddraft(interaction: discord.Interaction, winning_team: app_commands.
     await interaction.channel.delete()
 
 
-async def auto_start_draft(guild, channel):
+async def auto_start_draft(guild, channel, skip_middleman: bool = False):
     data = load_drafts()
     draft = data[str(channel.id)]
 
@@ -1021,17 +1178,20 @@ async def auto_start_draft(guild, channel):
     draft["pick_turn"] = "team1"
     save_drafts(data)
 
+    # Disable queue join/leave buttons now that the draft is starting
+    await disable_queue_buttons(channel)
+
     c1 = await guild.fetch_member(captains[0])
     c2 = await guild.fetch_member(captains[1])
     snake = draft["snake_draft"]
 
-    if draft.get("draft_type") == "friendly":
-        await send_actual_draft_start(channel)
-        await assign_team_roles(guild, channel, draft)
-        await send_pick_options(channel)
-        await dm_players_draft_started(channel)
-    elif draft.get("draft_type") == "wager":
+    if draft.get("is_money_draft") and not skip_middleman:
         await send_middleman_selection(channel)
+        return
+
+    await send_actual_draft_start(channel)
+    await send_pick_options(channel)
+    await dm_players_draft_started(channel)
 
 
 
@@ -1191,6 +1351,9 @@ async def finalize_draft_teams(channel):
     await move_members(draft["team1"] + [draft["captains"]["team1"]], team1_vc)
     await move_members(draft["team2"] + [draft["captains"]["team2"]], team2_vc)
 
+    if draft.get("is_money_draft"):
+        await send_double_prompt(channel)
+
 async def move_all_in_voice_channels(guild, vc_ids, target_channel_id):
     target_channel = guild.get_channel(target_channel_id)
     if not target_channel:
@@ -1213,9 +1376,6 @@ from email.header import decode_header
 import time
 import threading
 
-# Global payment trackers
-pending_payments = {}  # {channel_id: {cash_tag: user_id}}
-confirmed_payments = {}  # {channel_id: set(user_ids)}
 
 def check_cashapp_emails():
     while True:
@@ -1253,10 +1413,36 @@ def check_cashapp_emails():
 
                         print(f"📩 New email: {subject}")
 
-                        # Check each pending payment for matching cash tag
+                        drafts_snapshot = load_drafts()
+
+                        def norm(txt: str) -> str:
+                            return re.sub(r"[^a-z0-9]", "", txt.lower())
+
+                        sender_match = re.search(r"^(.*?) sent you", subject, re.IGNORECASE)
+                        sender = sender_match.group(1).strip() if sender_match else ""
+                        sender_norm = norm(sender)
+
+                        note_match = re.search(r"for\s+(\w{3})", subject, re.IGNORECASE)
+                        subject_note = note_match.group(1) if note_match else ""
+                        subject_note_norm = norm(subject_note)
+                        amt_match = re.search(r"\$(\d+(?:\.\d{1,2})?)", subject)
+                        amount_val = float(amt_match.group(1)) if amt_match else 0.0
+
                         for channel_id, tag_map in pending_payments.items():
+                            note = drafts_snapshot.get(str(channel_id), {}).get("payment_note", "")
+                            note_norm = norm(note)
+
+                            if note_norm and note_norm != subject_note_norm:
+                                continue
+
                             for tag, user_id in tag_map.items():
-                                if tag.lower() in subject.lower():
+                                tag_norm = norm(tag)
+
+                                if sender_norm == tag_norm:
+                                    entry_amt = drafts_snapshot.get(str(channel_id), {}).get("entry_amount", 0)
+                                    if abs(amount_val - entry_amt) > 0.01:
+                                        continue
+
                                     confirmed = confirmed_payments.setdefault(channel_id, set())
                                     if user_id in confirmed:
                                         continue
@@ -1270,7 +1456,17 @@ def check_cashapp_emails():
 
                                     if len(confirmed) == len(tag_map):
                                         if channel:
-                                            awaitable = auto_start_draft(channel.guild, channel)
+                                            current = drafts_snapshot.get(str(channel_id), {})
+                                            double_state = current.get("double", {}).get("state")
+                                            if double_state == "collecting":
+                                                awaitable = channel.send("@everyone Double payment received! Play again!")
+                                                data = load_drafts()
+                                                cur = data.get(str(channel_id), {})
+                                                if "double" in cur:
+                                                    cur["double"]["state"] = "complete"
+                                                save_drafts(data)
+                                            else:
+                                                awaitable = auto_start_draft(channel.guild, channel, skip_middleman=True)
                                             asyncio.run_coroutine_threadsafe(awaitable, bot.loop)
 
             mail.logout()


### PR DESCRIPTION
## Summary
- allow manual start to complete the double-or-nothing match without re-picking teams
- block duplicate Cash App usernames from players
- require both captains to agree on who lost before collecting double payments
- check payment amounts in emails and require correct entry fee

## Testing
- `python -m py_compile 'draft bot.py'`


------
https://chatgpt.com/codex/tasks/task_e_686970403fc48325a775b9d604c5d407